### PR TITLE
Fix for incorrect number of pagelinks when current page < 3

### DIFF
--- a/lib/pagination.js
+++ b/lib/pagination.js
@@ -87,8 +87,8 @@
 			return this._result;
 		},
 		calc : function() {
-			var totalResult = this.options.totalResult
-			var pageLinks = this.options.pageLinks
+			var totalResult = this.options.totalResult;
+			var pageLinks = this.options.pageLinks;
 			var rowsPerPage = this.options.rowsPerPage;
 			var current = this.options.current;
 			var startPage, endPage, pageCount;
@@ -128,7 +128,7 @@
 
 			if(startPage < 1) {
 				startPage = 1;
-				endPage = startPage + pageLinks;
+				endPage = startPage + pageLinks -1;
 				if(endPage > pageCount) {
 					endPage = pageCount;
 				}
@@ -258,7 +258,7 @@
 			translationCache.CURRENT_PAGE_REPORT[this.options.translationCacheKey] = new Function('fromResult, toResult, totalResult', template);
 		}
 		return translationCache.CURRENT_PAGE_REPORT[this.options.translationCacheKey](fromResult, toResult, totalResult);
-	}
+	};
 
 	ItemPaginator.prototype.render = function() {
 		var result = this.getPaginationData();
@@ -304,4 +304,4 @@
 				return new SearchPaginator(options);
 		}
 	};
-})(( typeof module !== 'undefined' && module.exports) ? module : undefined)
+})(( typeof module !== 'undefined' && module.exports) ? module : undefined);

--- a/tests/searchpagination.js
+++ b/tests/searchpagination.js
@@ -28,5 +28,16 @@ vows.describe('Test suite for SearchPaginator').addBatch({
 
 		assert.equal('<div class="paginator"><a href="/p/4" class="paginator-previous">Previous</a><a href="/p/3" class="paginator-page paginator-page-first">3</a><a href="/p/4" class="paginator-page">4</a><a href="/p/5" class="paginator-current">5</a><a href="/p/6" class="paginator-page">6</a><a href="/p/7" class="paginator-page paginator-page-last">7</a><a href="/p/6" class="paginator-next">Next</a></div>', item.render());
 
+	},
+	renderFirstPage : function() {
+		var item = new SearchPaginator({
+			prelink : '/',
+			pageLinks : 5,
+			current : 1,
+			totalResult : 100
+		});
+
+		assert.equal('<div class="paginator"><a href="/?page=1" class="paginator-current paginator-page-first">1</a><a href="/?page=2" class="paginator-page">2</a><a href="/?page=3" class="paginator-page">3</a><a href="/?page=4" class="paginator-page">4</a><a href="/?page=5" class="paginator-page paginator-page-last">5</a><a href="/?page=2" class="paginator-next">Next</a></div>', item.render());
+
 	}
-}).export(module)
+}).export(module);


### PR DESCRIPTION
When current page was 1 or 2, the number of links would be one to much.
Added some missing semicolons to shut up jslint.
