### PR TITLE
Fix for browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-var pkgs = ['item_paginator', 'search_paginator', 'template_paginator', 'template'];
-var pagination = require('./lib/pagination.js');
 var util = require('util');
-require('./lib/item_paginator')(pagination, util);
-require('./lib/search_paginator')(pagination, util);
-require('./lib/template_paginator')(pagination, util);
-require('./lib/template')(pagination, util);
+var pagination = require('./lib/pagination');
+require('./lib/item_paginator').module(pagination, util);
+require('./lib/search_paginator').module(pagination, util);
+require('./lib/template_paginator').module(pagination, util);
+require('./lib/template').module(pagination, util);
 
 module.exports = pagination;

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 var pkgs = ['item_paginator', 'search_paginator', 'template_paginator', 'template'];
 var pagination = require('./lib/pagination.js');
 var util = require('util');
-var i, len, pkg;
-for (i = 0, len = pkgs.length; i < len; i++) {
-	pkg = require('./lib/' + pkgs[i]  + '.js');
-	pkg.module(pagination, util);
-}
+require('./lib/item_paginator')(pagination, util);
+require('./lib/search_paginator')(pagination, util);
+require('./lib/template_paginator')(pagination, util);
+require('./lib/template')(pagination, util);
 
 module.exports = pagination;


### PR DESCRIPTION
Browserify can't process dynamic require() expressions so use static ones.